### PR TITLE
Pass an array, not a reference to the array

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Julia wrapper for [xxHash](https://github.com/Cyan4973/xxHash) C library
 julia> using XXhash
 
 julia> xxh64("abc")
-0x31886f2e7daf8ca4
+0x44bc2cf5ad770999
 
 julia> xxh32([5,3,'a'])
-0xd0602ac3
+0x2cc136fd
 
 julia> s=XXH64stream();
 

--- a/src/XXhash_h.jl
+++ b/src/XXhash_h.jl
@@ -25,6 +25,12 @@ end
    data, sizeof(data), seed % UInt32)
 end
 
+@inline function xxh32(data::String, seed::Union{Int64,UInt64}=0)::UInt64
+   ccall((:XXH32, libxxhash), Cuint,
+   (Cstring, Csize_t, Cuint),
+   data, sizeof(data), seed % UInt32)
+end
+
 struct XXH32_state_t
    total_len_32::UInt32
    large_len::UInt32
@@ -62,11 +68,16 @@ end
          state, input, len)
 end
 @inline function XXH32_update(state::Ptr{XXH32_state_t}, data::Array)::Cint
-   input = data
    len = sizeof(data)
    ccall((:XXH32_update, libxxhash), Cuint,
          (Ptr{XXH32_state_t}, Ptr{Cvoid}, Csize_t),
-         state, input, len)
+         state, data, len)
+end
+@inline function XXH32_update(state::Ptr{XXH32_state_t}, data::String)::Cint
+   len = sizeof(data)
+   ccall((:XXH32_update, libxxhash), Cuint,
+         (Ptr{XXH32_state_t}, CString, Csize_t),
+         state, data, len)
 end
 @inline function XXH32_digest(state::Ptr{XXH32_state_t})::UInt32
    ccall((:XXH32_digest, libxxhash), Cuint,
@@ -107,6 +118,11 @@ end
    (Ptr{Cvoid}, Csize_t, Culonglong),
    data, sizeof(data), seed % UInt64)
 end
+@inline function xxh64(data::String, seed::Union{Int64,UInt64}=0)::UInt64
+   ccall((:XXH64, libxxhash), Culonglong,
+   (Cstring, Csize_t, Culonglong),
+   data, sizeof(data), seed % UInt64)
+end
 
 struct XXH64_state_t
    total_len::UInt64
@@ -144,11 +160,16 @@ end
          state, input, len)
 end
 @inline function XXH64_update(state::Ptr{XXH64_state_t}, data::Array)::Cint
-   input = data
    len = sizeof(data)
    ccall((:XXH64_update, libxxhash), Cuint,
          (Ptr{XXH64_state_t}, Ptr{Cvoid}, Csize_t),
-         state, input, len)
+         state, data, len)
+end
+@inline function XXH64_update(state::Ptr{XXH64_state_t}, data::String)::Cint
+   len = sizeof(data)
+   ccall((:XXH64_update, libxxhash), Cuint,
+         (Ptr{XXH64_state_t}, Cstring, Csize_t),
+         state, data, len)
 end
 @inline function XXH64_digest(state::Ptr{XXH64_state_t})::UInt64
    ccall((:XXH64_digest, libxxhash), Culonglong,

--- a/src/XXhash_h.jl
+++ b/src/XXhash_h.jl
@@ -19,6 +19,12 @@ julia> xxh32("abc")
       Ref(data), sizeof(data), seed % UInt32)
 end
 
+@inline function xxh32(data::Array, seed::Union{Int64,UInt64}=0)::UInt64
+   ccall((:XXH32, libxxhash), Cuint,
+   (Ptr{Cvoid}, Csize_t, Cuint),
+   data, sizeof(data), seed % UInt32)
+end
+
 struct XXH32_state_t
    total_len_32::UInt32
    large_len::UInt32
@@ -50,6 +56,13 @@ end
 end
 @inline function XXH32_update(state::Ptr{XXH32_state_t}, data::Any)::Cint
    input = Ref(data)
+   len = sizeof(data)
+   ccall((:XXH32_update, libxxhash), Cuint,
+         (Ptr{XXH32_state_t}, Ptr{Cvoid}, Csize_t),
+         state, input, len)
+end
+@inline function XXH32_update(state::Ptr{XXH32_state_t}, data::Array)::Cint
+   input = data
    len = sizeof(data)
    ccall((:XXH32_update, libxxhash), Cuint,
          (Ptr{XXH32_state_t}, Ptr{Cvoid}, Csize_t),
@@ -89,6 +102,11 @@ julia> xxh64("abc")
    (Ptr{Cvoid}, Csize_t, Culonglong),
    Ref(data), sizeof(data), seed % UInt64)
 end
+@inline function xxh64(data::Array, seed::Union{Int64,UInt64}=0)::UInt64
+   ccall((:XXH64, libxxhash), Culonglong,
+   (Ptr{Cvoid}, Csize_t, Culonglong),
+   data, sizeof(data), seed % UInt64)
+end
 
 struct XXH64_state_t
    total_len::UInt64
@@ -120,6 +138,13 @@ end
 end
 @inline function XXH64_update(state::Ptr{XXH64_state_t}, data::Any)::Cint
    input = Ref(data)
+   len = sizeof(data)
+   ccall((:XXH64_update, libxxhash), Cuint,
+         (Ptr{XXH64_state_t}, Ptr{Cvoid}, Csize_t),
+         state, input, len)
+end
+@inline function XXH64_update(state::Ptr{XXH64_state_t}, data::Array)::Cint
+   input = data
    len = sizeof(data)
    ccall((:XXH64_update, libxxhash), Cuint,
          (Ptr{XXH64_state_t}, Ptr{Cvoid}, Csize_t),

--- a/src/XXhash_h.jl
+++ b/src/XXhash_h.jl
@@ -19,13 +19,13 @@ julia> xxh32("abc")
       Ref(data), sizeof(data), seed % UInt32)
 end
 
-@inline function xxh32(data::Array, seed::Union{Int64,UInt64}=0)::UInt64
+@inline function xxh32(data::Array, seed::Union{Int64,UInt64}=0)::UInt32
    ccall((:XXH32, libxxhash), Cuint,
    (Ptr{Cvoid}, Csize_t, Cuint),
    data, sizeof(data), seed % UInt32)
 end
 
-@inline function xxh32(data::String, seed::Union{Int64,UInt64}=0)::UInt64
+@inline function xxh32(data::String, seed::Union{Int64,UInt64}=0)::UInt32
    ccall((:XXH32, libxxhash), Cuint,
    (Cstring, Csize_t, Cuint),
    data, sizeof(data), seed % UInt32)

--- a/src/XXhash_h.jl
+++ b/src/XXhash_h.jl
@@ -10,7 +10,7 @@ Compute a hash of any object `d` using the 32 bit [xxHash](http://cyan4973.githu
 # Examples
 ```julia-repl
 julia> xxh32("abc")
-0xfe8990bc
+0x32d153ff
 ```
 """
 @inline function xxh32(data::Any, seed::Union{Int32,UInt32}=UInt32(0))::UInt32
@@ -105,7 +105,7 @@ Compute a hash of any object `d` using the 64 bit [xxHash](http://cyan4973.githu
 # Examples
 ```julia-repl
 julia> xxh64("abc")
-0x31886f2e7daf8ca4
+0x44bc2cf5ad770999
 ```
 """
 @inline function xxh64(data::Any, seed::Union{Int64,UInt64}=0)::UInt64

--- a/src/XXhash_h.jl
+++ b/src/XXhash_h.jl
@@ -76,7 +76,7 @@ end
 @inline function XXH32_update(state::Ptr{XXH32_state_t}, data::String)::Cint
    len = sizeof(data)
    ccall((:XXH32_update, libxxhash), Cuint,
-         (Ptr{XXH32_state_t}, CString, Csize_t),
+         (Ptr{XXH32_state_t}, Cstring, Csize_t),
          state, data, len)
 end
 @inline function XXH32_digest(state::Ptr{XXH32_state_t})::UInt32


### PR DESCRIPTION
Currently, the package is passing and hashing a reference to the array object, which results in hashes to be different for different arrays containing the same contents.

This PR adds a method for arrays that does not wrap the data in a `Ref`, so that the hash is computed on the array data.

Also does the same for strings.

Should fix #1 and fix #2