### PR TITLE
Fix `sizeof()` and adjust behavior for several `String` types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "0.8.1"
 [deps]
 CBinding = "d43a6710-96b8-4a2d-833c-c424785e5374"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 xxHash_jll = "5fdcd639-92d1-5a06-bf6b-28f2061df1a9"
 
 [compat]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,4 @@
+
+[deps]
+InlineStrings = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,43 +1,7 @@
-using XXhash, Test
+using Test
 
-@testset "xxhash" begin
-    s32 = XXH32stream()
-    s64 = XXH64stream()
-    s3_64 = XXH3_64stream()
-    s3_128 = XXH3_128stream()
-    r128 = rand(UInt128)
-    xxhash_update(s32, r128)
-    xxhash_update(s64, r128)
-    xxhash_update(s3_64, r128)
-    xxhash_update(s3_128, r128)
-    h32 = xxh32(r128)
-    h64 = xxh64(r128)
-    h3_64 = xxh3_64(r128)
-    h3_128 = xxh3_128(r128)
-    @testset "hash random 128 bit number" begin
-        @test xxhash_digest(s32) == h32
-        @test xxhash_digest(s64) == h64
-        @test xxhash_digest(s3_64) == h3_64
-        @test xxhash_digest(s3_128) == h3_128
-        @test xxhash_fromcanonical(xxhash_tocanonical(h32)) == h32
-        @test xxhash_fromcanonical(xxhash_tocanonical(h64)) == h64
-        @test xxhash_fromcanonical(xxhash_tocanonical(h3_128)) == h3_128
-    end
-    v = [rand(UInt8) for _ in 1:100]
-    s32 = XXH32stream()
-    s64 = XXH64stream()
-    s3_64 = XXH3_64stream()
-    s3_128 = XXH3_128stream()
-    for vi in v
-        xxhash_update(s32, vi)
-        xxhash_update(s64, vi)
-        xxhash_update(s3_64, vi)
-        xxhash_update(s3_128, vi)
-    end
-    @testset "hash a vector of bytes" begin
-        @test xxhash_digest(s32) == xxh32(v)
-        @test xxhash_digest(s64) == xxh64(v)
-        @test xxhash_digest(s3_64) == xxh3_64(v)
-        @test xxhash_digest(s3_128) == xxh3_128(v)
-    end
+files = isempty(ARGS) ? filter(contains(r"^test_.*\.jl$"), readdir(@__DIR__)) : ARGS
+
+@testset for file in files
+    include(file)
 end

--- a/test/test_basic.jl
+++ b/test/test_basic.jl
@@ -1,0 +1,47 @@
+module BasicTests
+
+using XXhash, Test
+
+@testset "xxhash" begin
+    s32 = XXH32stream()
+    s64 = XXH64stream()
+    s3_64 = XXH3_64stream()
+    s3_128 = XXH3_128stream()
+    r128 = rand(UInt128)
+    xxhash_update(s32, r128)
+    xxhash_update(s64, r128)
+    xxhash_update(s3_64, r128)
+    xxhash_update(s3_128, r128)
+    h32 = xxh32(r128)
+    h64 = xxh64(r128)
+    h3_64 = xxh3_64(r128)
+    h3_128 = xxh3_128(r128)
+    @testset "hash random 128 bit number" begin
+        @test xxhash_digest(s32) == h32
+        @test xxhash_digest(s64) == h64
+        @test xxhash_digest(s3_64) == h3_64
+        @test xxhash_digest(s3_128) == h3_128
+        @test xxhash_fromcanonical(xxhash_tocanonical(h32)) == h32
+        @test xxhash_fromcanonical(xxhash_tocanonical(h64)) == h64
+        @test xxhash_fromcanonical(xxhash_tocanonical(h3_128)) == h3_128
+    end
+    v = [rand(UInt8) for _ in 1:100]
+    s32 = XXH32stream()
+    s64 = XXH64stream()
+    s3_64 = XXH3_64stream()
+    s3_128 = XXH3_128stream()
+    for vi in v
+        xxhash_update(s32, vi)
+        xxhash_update(s64, vi)
+        xxhash_update(s3_64, vi)
+        xxhash_update(s3_128, vi)
+    end
+    @testset "hash a vector of bytes" begin
+        @test xxhash_digest(s32) == xxh32(v)
+        @test xxhash_digest(s64) == xxh64(v)
+        @test xxhash_digest(s3_64) == xxh3_64(v)
+        @test xxhash_digest(s3_128) == xxh3_128(v)
+    end
+end
+
+end  # module

--- a/test/test_strings.jl
+++ b/test/test_strings.jl
@@ -1,0 +1,136 @@
+module StringTests
+
+using XXhash
+using InlineStrings
+using Test
+
+function test_xxhxx(xxhxx, res1, expected1, res2, expected2)
+    @test xxhxx(res1) == xxhxx(expected1)
+    @test xxhxx(res2) == xxhxx(expected2)
+    @test xxhxx(res1) != xxhxx(res2)
+end
+
+function test_xxhxstream(::Type{StreamType}, xxhxx, res) where StreamType
+    s = StreamType()
+    xxhash_update(s, res)
+    @test xxhash_digest(s) == xxhxx(res)
+end
+
+@testset "String" begin
+    str1 = "abc"
+    str2 = "123"
+    test_xxhxx(xxh32, str1, "abc", str2, "123")
+    test_xxhxx(xxh64, str1, "abc", str2, "123")
+    test_xxhxx(xxh3_64, str1, "abc", str2, "123")
+    test_xxhxx(xxh3_128, str1, "abc", str2, "123")
+    test_xxhxstream(XXH32stream, xxh32, str1)
+    test_xxhxstream(XXH64stream, xxh64, str1)
+    test_xxhxstream(XXH3_64stream, xxh3_64, str1)
+    test_xxhxstream(XXH3_128stream, xxh3_128, str1)
+end
+
+@testset "String1" begin
+    str1 = String1("a")
+    str2 = String1("1")
+    test_xxhxx(xxh32, str1, inline1"a", str2, inline1"1")
+    test_xxhxx(xxh64, str1, inline1"a", str2, inline1"1")
+    test_xxhxx(xxh3_64, str1, inline1"a", str2, inline1"1")
+    test_xxhxx(xxh3_128, str1, inline1"a", str2, inline1"1")
+    test_xxhxstream(XXH32stream, xxh32, str1)
+    test_xxhxstream(XXH64stream, xxh64, str1)
+    test_xxhxstream(XXH3_64stream, xxh3_64, str1)
+    test_xxhxstream(XXH3_128stream, xxh3_128, str1)
+end
+
+@testset "String3" begin
+    str1 = String3("abc")
+    str2 = String3("123")
+    test_xxhxx(xxh32, str1, inline3"abc", str2, inline3"123")
+    test_xxhxx(xxh64, str1, inline3"abc", str2, inline3"123")
+    test_xxhxx(xxh3_64, str1, inline3"abc", str2, inline3"123")
+    test_xxhxx(xxh3_128, str1, inline3"abc", str2, inline3"123")
+    test_xxhxstream(XXH32stream, xxh32, str1)
+    test_xxhxstream(XXH64stream, xxh64, str1)
+    test_xxhxstream(XXH3_64stream, xxh3_64, str1)
+    test_xxhxstream(XXH3_128stream, xxh3_128, str1)
+end
+
+@testset "String7" begin
+    str1 = String7("abc")
+    str2 = String7("123")
+    test_xxhxx(xxh32, str1, inline7"abc", str2, inline7"123")
+    test_xxhxx(xxh64, str1, inline7"abc", str2, inline7"123")
+    test_xxhxx(xxh3_64, str1, inline7"abc", str2, inline7"123")
+    test_xxhxx(xxh3_128, str1, inline7"abc", str2, inline7"123")
+    test_xxhxstream(XXH32stream, xxh32, str1)
+    test_xxhxstream(XXH64stream, xxh64, str1)
+    test_xxhxstream(XXH3_64stream, xxh3_64, str1)
+    test_xxhxstream(XXH3_128stream, xxh3_128, str1)
+end
+
+@testset "String15" begin
+    str1 = String15("abc")
+    str2 = String15("123")
+    test_xxhxx(xxh32, str1, inline15"abc", str2, inline15"123")
+    test_xxhxx(xxh64, str1, inline15"abc", str2, inline15"123")
+    test_xxhxx(xxh3_64, str1, inline15"abc", str2, inline15"123")
+    test_xxhxx(xxh3_128, str1, inline15"abc", str2, inline15"123")
+    test_xxhxstream(XXH32stream, xxh32, str1)
+    test_xxhxstream(XXH64stream, xxh64, str1)
+    test_xxhxstream(XXH3_64stream, xxh3_64, str1)
+    test_xxhxstream(XXH3_128stream, xxh3_128, str1)
+end
+
+@testset "String31" begin
+    str1 = String31("abc")
+    str2 = String31("123")
+    test_xxhxx(xxh32, str1, inline31"abc", str2, inline31"123")
+    test_xxhxx(xxh64, str1, inline31"abc", str2, inline31"123")
+    test_xxhxx(xxh3_64, str1, inline31"abc", str2, inline31"123")
+    test_xxhxx(xxh3_128, str1, inline31"abc", str2, inline31"123")
+    test_xxhxstream(XXH32stream, xxh32, str1)
+    test_xxhxstream(XXH64stream, xxh64, str1)
+    test_xxhxstream(XXH3_64stream, xxh3_64, str1)
+    test_xxhxstream(XXH3_128stream, xxh3_128, str1)
+end
+
+@testset "String63" begin
+    str1 = String63("abc")
+    str2 = String63("123")
+    test_xxhxx(xxh32, str1, inline63"abc", str2, inline63"123")
+    test_xxhxx(xxh64, str1, inline63"abc", str2, inline63"123")
+    test_xxhxx(xxh3_64, str1, inline63"abc", str2, inline63"123")
+    test_xxhxx(xxh3_128, str1, inline63"abc", str2, inline63"123")
+    test_xxhxstream(XXH32stream, xxh32, str1)
+    test_xxhxstream(XXH64stream, xxh64, str1)
+    test_xxhxstream(XXH3_64stream, xxh3_64, str1)
+    test_xxhxstream(XXH3_128stream, xxh3_128, str1)
+end
+
+@testset "String127" begin
+    str1 = String127("abc")
+    str2 = String127("123")
+    test_xxhxx(xxh32, str1, inline127"abc", str2, inline127"123")
+    test_xxhxx(xxh64, str1, inline127"abc", str2, inline127"123")
+    test_xxhxx(xxh3_64, str1, inline127"abc", str2, inline127"123")
+    test_xxhxx(xxh3_128, str1, inline127"abc", str2, inline127"123")
+    test_xxhxstream(XXH32stream, xxh32, str1)
+    test_xxhxstream(XXH64stream, xxh64, str1)
+    test_xxhxstream(XXH3_64stream, xxh3_64, str1)
+    test_xxhxstream(XXH3_128stream, xxh3_128, str1)
+end
+
+@testset "SubString" begin
+    str1 = SubString("abc", 1, 3)  # == "abc"
+    str2 = SubString("123", 1, 3)  # == "123"
+    test_xxhxx(xxh32, str1, SubString("*abc_", 2, 4), str2, SubString("01234", 2, 4))
+    test_xxhxx(xxh64, str1, SubString("*abc_", 2, 4), str2, SubString("01234", 2, 4))
+    test_xxhxx(xxh3_64, str1, SubString("*abc_", 2, 4), str2, SubString("01234", 2, 4))
+    test_xxhxx(xxh3_128, str1, SubString("*abc_", 2, 4), str2, SubString("01234", 2, 4))
+    test_xxhxstream(XXH32stream, xxh32, str1)
+    test_xxhxstream(XXH64stream, xxh64, str1)
+    test_xxhxstream(XXH3_64stream, xxh3_64, str1)
+    test_xxhxstream(XXH3_128stream, xxh3_128, str1)
+end
+
+end  # module


### PR DESCRIPTION
* Updated the usage of `sizeof()` (i.e., `Base.sizeof()`) to ensure that either `Core.sizeof()` (which returns the generally correct allocated memory size) or `Base.sizeof()` (which returns a meaningfully optimized memory size for the specific type) is selected appropriately.
* Added tests for `String`, `SubString`, and InlineString types.

This PR resolves the issue reported in https://github.com/hros/XXhash.jl/issues/8.